### PR TITLE
Fix continuous features with similar prefix

### DIFF
--- a/dice_ml/data_interfaces/public_data_interface.py
+++ b/dice_ml/data_interfaces/public_data_interface.py
@@ -216,7 +216,8 @@ class PublicData:
         cols = []
         for col_parent in self.categorical_feature_names:
             temp = [self.encoded_feature_names.index(
-                col) for col in self.encoded_feature_names if col.startswith(col_parent)]
+                col) for col in self.encoded_feature_names if col.startswith(col_parent) and
+                   col not in self.continuous_feature_names]
             cols.append(temp)
         return cols
 


### PR DESCRIPTION
This simple change fix a possible error when a continuous feature has the same prefix as a categorical one (`col.startswith(col_parent)` would be `True` in this case). With that small addition, this would not happen.